### PR TITLE
Add cucumber test for Menu validaCPF

### DIFF
--- a/backoffice_pi/pom.xml
+++ b/backoffice_pi/pom.xml
@@ -32,6 +32,20 @@
           <scope>test</scope>
        </dependency>
 
+        <!-- Dependências para testes Cucumber -->
+        <dependency>
+            <groupId>io.cucumber</groupId>
+            <artifactId>cucumber-java</artifactId>
+            <version>7.16.1</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.cucumber</groupId>
+            <artifactId>cucumber-junit-platform-engine</artifactId>
+            <version>7.16.1</version>
+            <scope>test</scope>
+        </dependency>
+
 
         <dependency>
             <groupId>org.mindrot</groupId>

--- a/backoffice_pi/src/test/java/com/example/steps/MenuStepDefinitions.java
+++ b/backoffice_pi/src/test/java/com/example/steps/MenuStepDefinitions.java
@@ -1,0 +1,24 @@
+package com.example.steps;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import com.example.classes.Menu;
+
+import io.cucumber.java.en.Then;
+import io.cucumber.java.en.When;
+
+public class MenuStepDefinitions {
+
+    private boolean resultado;
+
+    @When("valido o CPF {string}")
+    public void valido_o_cpf(String cpf) {
+        resultado = Menu.validaCPF(cpf);
+    }
+
+    @Then("o resultado deve ser {string}")
+    public void o_resultado_deve_ser(String esperado) {
+        boolean esperadoBool = Boolean.parseBoolean(esperado);
+        assertEquals(esperadoBool, resultado);
+    }
+}

--- a/backoffice_pi/src/test/java/com/example/steps/RunCucumberTest.java
+++ b/backoffice_pi/src/test/java/com/example/steps/RunCucumberTest.java
@@ -1,0 +1,7 @@
+package com.example.steps;
+
+import io.cucumber.junit.platform.engine.Cucumber;
+
+@Cucumber
+public class RunCucumberTest {
+}

--- a/backoffice_pi/src/test/resources/features/menu_valida_cpf.feature
+++ b/backoffice_pi/src/test/resources/features/menu_valida_cpf.feature
@@ -1,0 +1,9 @@
+Feature: Validacao de CPF
+
+  Scenario: CPF valido
+    When valido o CPF "52998224725"
+    Then o resultado deve ser "true"
+
+  Scenario: CPF invalido
+    When valido o CPF "12345678900"
+    Then o resultado deve ser "false"


### PR DESCRIPTION
## Summary
- add Cucumber dependencies to `backoffice_pi`
- create feature file to validate CPF
- implement step definitions and runner

## Testing
- `mvn -q test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68436c883d1c832496c3e76b81de17da